### PR TITLE
Fix | sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Track your time in bash, zsh, and fish with WakaTime! Better alternative to the 
 ## Quick Setup (30 seconds)
 
 ```bash
-curl -fsSL http://hack.club/terminal-wakatime.sh | sh
+curl -fsSL http://hack.club/terminal-wakatime.sh | $(basename "$SHELL")
 ```
 
 This installs `terminal-wakatime` to `~/.wakatime/terminal-wakatime` and adds `eval "$(terminal-wakatime init)"` to your `~/.bashrc`, `~/.zshrc`, or `~/.config/fish/config.fish`.
@@ -82,7 +82,7 @@ Today's Coding Time: 6h 45m
 ### Quick Install (Recommended)
 
 ```bash
-curl -fsSL http://hack.club/tw.sh | sh
+curl -fsSL http://hack.club/tw.sh | $(basename "$SHELL")
 ```
 
 ### Manual Install

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Track your time in bash, zsh, and fish with WakaTime! Better alternative to the 
 ## Quick Setup (30 seconds)
 
 ```bash
-curl -fsSL http://hack.club/terminal-wakatime.sh | $(basename "$SHELL")
+curl -fsSL http://hack.club/terminal-wakatime.sh | bash
 ```
 
 This installs `terminal-wakatime` to `~/.wakatime/terminal-wakatime` and adds `eval "$(terminal-wakatime init)"` to your `~/.bashrc`, `~/.zshrc`, or `~/.config/fish/config.fish`.
@@ -82,7 +82,7 @@ Today's Coding Time: 6h 45m
 ### Quick Install (Recommended)
 
 ```bash
-curl -fsSL http://hack.club/tw.sh | $(basename "$SHELL")
+curl -fsSL http://hack.club/tw.sh | bash
 ```
 
 ### Manual Install


### PR DESCRIPTION
sh is POSIX-compliant, but this script uses non-POSIX features; thus pipe into the user's current shell (bash/zsh/etc) instead