### PR TITLE
bug: use self for less copying to the nix store

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -19,11 +19,11 @@
     in
     {
       packages = forAllSystems ({ pkgs }: {
-        default = pkgs.buildGoModule rec {
+        default = pkgs.buildGoModule {
           pname = "terminal-wakatime";
           version = "1.1.5";
           subPackages = [ "cmd/terminal-wakatime" ];
-          src = ./.;
+          src = self;
           vendorHash = "sha256-fchZVBY43ccu6nbWn572Qzfgeq4uIwpLf99lOuJCO44=";
         };
       });

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
       packages = forAllSystems ({ pkgs }: {
         default = pkgs.buildGoModule {
           pname = "terminal-wakatime";
-          version = "1.1.5";
+          version = "1.1.6";
           subPackages = [ "cmd/terminal-wakatime" ];
           src = self;
           vendorHash = "sha256-fchZVBY43ccu6nbWn572Qzfgeq4uIwpLf99lOuJCO44=";


### PR DESCRIPTION
i realized that i did the flake a bit weirdly the first time around and that caused it to be unnecessarily wasteful

i bumped the version to 1.1.6 but i can remove that commit if you don't want to release yet