### PR TITLE
Prevent environment variables from becoming heartbeat entities

### DIFF
--- a/pkg/tracker/tracker.go
+++ b/pkg/tracker/tracker.go
@@ -189,7 +189,7 @@ func (t *Tracker) TrackFile(filePath string, isWrite bool) error {
 }
 
 func (t *Tracker) parseCommandToSingleActivity(command string, workingDir string) *Activity {
-	fields := strings.Fields(command)
+	fields := commandFields(command)
 	if len(fields) == 0 {
 		return nil
 	}
@@ -224,7 +224,7 @@ func (t *Tracker) parseCommandToSingleActivity(command string, workingDir string
 	}
 
 	// Check for remote connections
-	if domain := t.parseRemoteConnection(command); domain != "" {
+	if domain := t.parseRemoteConnection(strings.Join(fields, " ")); domain != "" {
 		return &Activity{
 			Entity:     domain,
 			EntityType: ActivityDomain,
@@ -260,6 +260,36 @@ func (t *Tracker) parseCommandToSingleActivity(command string, workingDir string
 		Branch:     getGitBranch(workingDir),
 		Timestamp:  time.Now(),
 	}
+}
+
+func commandFields(command string) []string {
+	fields := strings.Fields(command)
+	for len(fields) > 0 && isEnvironmentAssignment(fields[0]) {
+		fields = fields[1:]
+	}
+	return fields
+}
+
+func isEnvironmentAssignment(field string) bool {
+	separator := strings.IndexByte(field, '=')
+	if separator <= 0 {
+		return false
+	}
+
+	name := field[:separator]
+	if (name[0] < 'A' || name[0] > 'Z') && (name[0] < 'a' || name[0] > 'z') && name[0] != '_' {
+		return false
+	}
+
+	for _, character := range name[1:] {
+		if (character < 'A' || character > 'Z') &&
+			(character < 'a' || character > 'z') &&
+			(character < '0' || character > '9') && character != '_' {
+			return false
+		}
+	}
+
+	return true
 }
 
 func (t *Tracker) isEditor(cmdName string) bool {

--- a/pkg/tracker/tracker_test.go
+++ b/pkg/tracker/tracker_test.go
@@ -86,6 +86,25 @@ func TestParseCommandToSingleActivity(t *testing.T) {
 	}
 }
 
+func TestParseCommandSkipsEnvironmentAssignments(t *testing.T) {
+	tracker := NewTracker(&config.Config{Project: "test-project"})
+
+	activity := tracker.parseCommandToSingleActivity("MY_API_KEY=abcd234 ./executable", "/tmp")
+	if activity == nil {
+		t.Fatal("expected an activity")
+	}
+	if activity.Entity != "executable" {
+		t.Fatalf("expected executable entity, got %q", activity.Entity)
+	}
+	if activity.EntityType != ActivityApp {
+		t.Fatalf("expected app entity type, got %q", activity.EntityType)
+	}
+
+	if activity := tracker.parseCommandToSingleActivity("MY_API_KEY=abcd234", "/tmp"); activity != nil {
+		t.Fatalf("expected assignment-only command to be ignored, got %+v", activity)
+	}
+}
+
 func TestIsEditor(t *testing.T) {
 	cfg := &config.Config{}
 	tracker := NewTracker(cfg)


### PR DESCRIPTION
Strip leading `NAME=value` assignments from tracked shell commands so secrets are not recorded as heartbeat entities.

Assignment-only commands are ignored, and regression tests cover the reported API key case.

Closes #14